### PR TITLE
Travel groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,6 +1403,11 @@
         "yaml": "^1.7.2"
       }
     },
+    "country-state-picker": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/country-state-picker/-/country-state-picker-1.1.5.tgz",
+      "integrity": "sha512-YzQ35FsJG1YHSqHbitFY8ov7H2ghOGmYY1H6+G363J6j9+zxzdvk3jicEvzSmY7E08+2WQqX63jzCJmaRYMYSA=="
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^0.26.1",
     "bcryptjs": "^2.4.3",
     "cloudinary": "^1.29.0",
+    "country-state-picker": "^1.1.5",
     "dayjs": "^1.11.0",
     "faunadb": "^4.5.2",
     "formidable": "^1.2.2",

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,0 +1,20 @@
+import dayjs, {Dayjs} from "dayjs";
+import { useState } from "react";
+import styles from '../../styles/Calendar.module.css'
+import Cells from "./Cells";
+import Header from './Header'
+import WeekDays from "./WeekDays";
+
+export default function Calendar() {
+
+    const [currentDate, setCurrentDate] = useState(dayjs())
+    const [selectedDates, setSelectedDates] = useState<Dayjs[]>([])
+
+    return (
+        <div className={styles.calendar}>
+            <Header currentDate={currentDate} setCurrentDate={setCurrentDate} />
+            <WeekDays />
+            <Cells currentDate={currentDate} />
+        </div>
+    )
+}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -5,16 +5,77 @@ import Cells from "./Cells";
 import Header from './Header'
 import WeekDays from "./WeekDays";
 
-export default function Calendar() {
+interface Props {
+    dateRange: [Dayjs, Dayjs];
+    onDateRangeChange: (dateRange:[Dayjs, Dayjs]) => void;
+}
+
+export default function Calendar({dateRange, onDateRangeChange}:Props) {
 
     const [currentDate, setCurrentDate] = useState(dayjs())
-    const [selectedDates, setSelectedDates] = useState<Dayjs[]>([])
+
+    const [tempRange, setTempRange] = useState<Dayjs[]>([])
+
+    const onMouseDown = (day:Dayjs) => {
+        setTempRange([day, day, day])
+    }
+
+    const onMouseMove = (day:Dayjs) => {
+        if (!tempRange[0]) return
+
+        if (tempRange[0].isSame(day))  {
+            return
+        }
+
+        if (tempRange[1].isSame(day)) {
+            return
+        }
+
+        if (day.isBefore(tempRange[0])) {
+            if (day.isBefore(tempRange[2])) {
+                return setTempRange([day, tempRange[2], tempRange[2]])
+            }
+            return setTempRange([day, tempRange[2], tempRange[2]])
+        }
+
+        if (day.isAfter(tempRange[1])) {
+            if (day.isAfter(tempRange[2])) {
+                return setTempRange([tempRange[2], day, tempRange[2]])
+            }
+            return setTempRange([tempRange[0], day, tempRange[2]])
+        }
+
+        if (day.isAfter(tempRange[2])) {
+            return setTempRange([tempRange[0], day, tempRange[2]])
+        }
+
+        setTempRange([day, tempRange[1], tempRange[2]])
+    }
+
+    const onMouseUp = () => {
+        if (tempRange.length === 0) return
+
+        if (dateRange[0] && dateRange[0].isSame(dateRange[1]) && tempRange[0].isSame(tempRange[1])) {
+            const lower = dateRange[0].isBefore(tempRange[0]) ? dateRange[0] : tempRange[0]
+            const upper = dateRange[0].isSame(lower) ? tempRange[0] : dateRange[0]
+
+            setTempRange([])
+            return onDateRangeChange([lower, upper])
+        }
+
+        const lower = tempRange[0].subtract(1, 'day').isSame(dateRange[1], 'day') ? dateRange[0] : tempRange[0]
+        const upper = tempRange[1].add(1, 'day').isSame(dateRange[0], 'day') ? dateRange[1] : tempRange[1]
+
+        setTempRange([])
+        onDateRangeChange([lower, upper])
+    }
 
     return (
         <div className={styles.calendar}>
             <Header currentDate={currentDate} setCurrentDate={setCurrentDate} />
             <WeekDays />
-            <Cells currentDate={currentDate} />
+            <Cells dateRange={dateRange} tempRange={tempRange} onMouseDown={onMouseDown} onMouseMove={onMouseMove}
+            onMouseUp={onMouseUp} currentDate={currentDate} />
         </div>
     )
 }

--- a/src/components/calendar/Cells.tsx
+++ b/src/components/calendar/Cells.tsx
@@ -4,6 +4,11 @@ import styles from '../../styles/Calendar.module.css'
 
 interface Props {
     currentDate: Dayjs;
+    tempRange: Dayjs[];
+    dateRange: [Dayjs, Dayjs];
+    onMouseDown: (day:Dayjs) => void;
+    onMouseMove: (day:Dayjs) => void;
+    onMouseUp: () => void;
 }
 
 interface Day {
@@ -12,7 +17,7 @@ interface Day {
     date: Dayjs;
 }
 
-export default function Cells({currentDate}:Props) {
+export default function Cells({currentDate, tempRange, dateRange, onMouseDown, onMouseMove, onMouseUp}:Props) {
 
     const [monthStart, monthEnd] = useMemo(() => {
         return [currentDate.startOf('month'), currentDate.endOf('month')]
@@ -37,15 +42,28 @@ export default function Cells({currentDate}:Props) {
     }, [currentDate])
 
     return (
-        <div className={styles.body}>
+        <div className={styles.body} onMouseLeave={() => onMouseUp()}>
             {Array(days.length / 7).fill(null).map((_, row) => (
                 <div className={styles.row} key={row}>
                     {Array(7).fill(null).map((_, col) => {
                         const day = days[(row * 7) + col]
+                        let inTempRange = false, inDateRange = false
+                        if (tempRange.length === 0) inTempRange = false
+                        else if ((day.date.isAfter(tempRange[0]) || day.date.isSame(tempRange[0], 'day')) 
+                        && (day.date.isBefore(tempRange[1]) || day.date.isSame(tempRange[1], 'day'))) {
+                            inTempRange = true
+                        }
+                        if (inTempRange) inDateRange = false
+                        else if ((day.date.isAfter(dateRange[0]) || day.date.isSame(dateRange[0], 'day')) 
+                        && (day.date.isBefore(dateRange[1]) || day.date.isSame(dateRange[1], 'day'))) {
+                            inDateRange = true
+                        }
                         return (
-                            <div className={`${styles.column} ${styles.cell} ${day.inMonth ? '' : styles.disabled}`} key={col}>
+                            <div className={`${styles.column} ${styles.cell} ${day.inMonth ? '' : styles.disabled} 
+                            ${inTempRange ? styles.inRange : ''} ${inDateRange ? styles.inPrevSelectedRange : ''}`} key={col}
+                            onMouseDown={() => onMouseDown(day.date)} onMouseUp={() => onMouseUp()}
+                            onMouseMove={() => onMouseMove(day.date)} >
                                 {day.inMonth && <span className={styles.number}>{day.date.format('D')}</span>}
-
                             </div>
                         )
                     })}

--- a/src/components/calendar/Cells.tsx
+++ b/src/components/calendar/Cells.tsx
@@ -1,0 +1,56 @@
+import dayjs, { Dayjs } from "dayjs";
+import { useMemo, useState } from "react";
+import styles from '../../styles/Calendar.module.css'
+
+interface Props {
+    currentDate: Dayjs;
+}
+
+interface Day {
+    inMonth: boolean;
+    status: string;
+    date: Dayjs;
+}
+
+export default function Cells({currentDate}:Props) {
+
+    const [monthStart, monthEnd] = useMemo(() => {
+        return [currentDate.startOf('month'), currentDate.endOf('month')]
+    }, [currentDate])
+
+    const [startDate, endDate] = useMemo(() => {
+        return [monthStart.startOf('week'), monthEnd.endOf('week')]
+    }, [monthStart, monthEnd])
+
+    const [days, setDays] = useState<Day[]>([])
+
+    useMemo(() => {
+        const newDays = []
+        for (let day = startDate; day.isBefore(endDate) || day.isSame(endDate, 'day'); day = day.add(1, 'day')) {
+            newDays.push({
+                inMonth: day.isSame(currentDate, 'month'),
+                status: 'who cares yet',
+                date: day
+            })
+        }
+        setDays(newDays)
+    }, [currentDate])
+
+    return (
+        <div className={styles.body}>
+            {Array(days.length / 7).fill(null).map((_, row) => (
+                <div className={styles.row} key={row}>
+                    {Array(7).fill(null).map((_, col) => {
+                        const day = days[(row * 7) + col]
+                        return (
+                            <div className={`${styles.column} ${styles.cell} ${day.inMonth ? '' : styles.disabled}`} key={col}>
+                                {day.inMonth && <span className={styles.number}>{day.date.format('D')}</span>}
+
+                            </div>
+                        )
+                    })}
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/components/calendar/Header.tsx
+++ b/src/components/calendar/Header.tsx
@@ -1,0 +1,44 @@
+import { IconButton, Typography } from '@mui/material';
+import dayjs, {Dayjs} from 'dayjs'
+import { Dispatch, SetStateAction } from 'react';
+import styles from '../../styles/Calendar.module.css'
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore'
+import NavigateNextIcon from '@mui/icons-material/NavigateNext'
+
+interface Props {
+    currentDate: Dayjs;
+    setCurrentDate: Dispatch<SetStateAction<Dayjs>>;
+}
+
+export default function Header({currentDate, setCurrentDate}:Props) {
+
+    const next = () => {
+        setCurrentDate(currentDate.add(1, 'month'))
+    }
+
+    const prev = () => {
+        setCurrentDate(currentDate.subtract(1, 'month'))
+    }
+
+    return (
+        <div className={`${styles.header} ${styles.row} ${styles.flexMiddle}`}>
+            <div className={`${styles.column} ${styles.colStart}`}>
+                <IconButton disabled={currentDate.subtract(1, 'month').isBefore(dayjs().startOf('month'))} onClick={() => prev()}>
+                    <NavigateBeforeIcon /> 
+                </IconButton>
+            </div>
+            <div className={`${styles.column} ${styles.colCenter}`}>
+                <span>
+                    <Typography variant="h5">
+                        {currentDate.format('MMMM YYYY')}
+                    </Typography>
+                </span>
+            </div>
+            <div className={`${styles.column} ${styles.colEnd}`}>
+                <IconButton onClick={() => next()}>
+                    <NavigateNextIcon />
+                </IconButton>
+            </div>
+        </div>
+    )
+}

--- a/src/components/calendar/WeekDays.tsx
+++ b/src/components/calendar/WeekDays.tsx
@@ -1,0 +1,21 @@
+import { Typography } from '@mui/material'
+import dayjs from 'dayjs'
+import { useMemo } from 'react'
+import styles from '../../styles/Calendar.module.css'
+
+export default function WeekDays() {
+
+    const weekDays = useMemo(() => ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'], [])
+
+    return (
+        <div className={`${styles.days} ${styles.row}`}>
+            {weekDays.map(day => (
+                <div key={day} className={`${styles.column} ${styles.colCenter}`}>
+                    <Typography variant="subtitle2">
+                        {day}
+                    </Typography>
+                </div>
+            ))} 
+        </div>
+    )
+}

--- a/src/components/forms/FormikFields.tsx
+++ b/src/components/forms/FormikFields.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react'
-import {useField, Field} from 'formik'
-import {TextField, InputAdornment, IconButton} from '@mui/material'
+import {useField, Field, Form} from 'formik'
+import {TextField, InputAdornment, IconButton, Select, FormControl, InputLabel, FormHelperText, Autocomplete} from '@mui/material'
 import VisibilityIcon from '@mui/icons-material/VisibilityOutlined'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOffOutlined'
 import styles from '../../styles/Forms.module.css'
@@ -19,6 +19,19 @@ export const FormikTextField = (props) => {
         <Field {...props} {...field} as={TextField} error={meta.touched && Boolean(meta.error)}
         helperText={meta.touched && meta.error ? meta.error : ''}
         InputProps={{...inputProps, ...props.InputProps}} InputLabelProps={inputLabelProps} FormHelperTextProps={formHelperTextProps} />
+    )
+}
+
+export const FormikSelectField = (props) => {
+    const [field, meta] = useField({
+        name: props.name,
+    })
+    return (
+        <FormControl error={meta.touched && Boolean(meta.error)}>
+            <InputLabel>{props.label}</InputLabel>
+            <Select {...props} {...field} />
+            {meta.touched && meta.error && <FormHelperText>{meta.error}</FormHelperText>}
+        </FormControl>
     )
 }
 

--- a/src/components/forms/FormikFields.tsx
+++ b/src/components/forms/FormikFields.tsx
@@ -1,6 +1,7 @@
 import {useState} from 'react'
 import {useField, Field, Form} from 'formik'
-import {TextField, InputAdornment, IconButton, Select, FormControl, InputLabel, FormHelperText, Autocomplete} from '@mui/material'
+import {TextField, InputAdornment, IconButton, Select, FormControl, InputLabel, FormHelperText, Autocomplete, 
+Grid, Radio, Box, Typography} from '@mui/material'
 import VisibilityIcon from '@mui/icons-material/VisibilityOutlined'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOffOutlined'
 import styles from '../../styles/Forms.module.css'
@@ -67,5 +68,37 @@ export const FormikPasswordField = (props) => {
                 {visible ? <VisibilityIcon /> : <VisibilityOffIcon />}
             </IconButton>
         </InputAdornment>}} InputLabelProps={inputLabelProps} FormHelperTextProps={formHelperTextProps} />
+    )
+}
+
+interface RadioWithDescProps {
+    value: string;
+    selectedValue: string;
+    primaryText: string;
+    secondaryText: string;
+}
+
+export function RadioWithDesc({value, selectedValue, primaryText, secondaryText}:RadioWithDescProps) {
+
+    return (
+        <Grid container wrap="nowrap" alignItems="center">
+            <Grid item>
+                <Radio id={secondaryText + value} value={value} />
+            </Grid>
+            <Grid item>
+                <label htmlFor={secondaryText + value}>
+                    <Box>
+                        <Typography variant={selectedValue === value ? 'h6' : 'body1'}>
+                            {primaryText}
+                        </Typography>
+                    </Box>
+                    {selectedValue === value && <Box>
+                        <Typography color="rgba(0,0,0,0.7)" variant="body2">
+                            {secondaryText}
+                        </Typography>
+                    </Box>}
+                </label>
+            </Grid>
+        </Grid>
     )
 }

--- a/src/components/forms/travel-groups/create/Destination.tsx
+++ b/src/components/forms/travel-groups/create/Destination.tsx
@@ -6,7 +6,7 @@ import {object, string} from 'yup'
 import FormObserver from '../../FormObserver'
 import { TravelGroup } from '../../../../database/interfaces'
 import {MenuItem, Autocomplete, TextField} from '@mui/material'
-import { getCountries, getStates } from 'country-state-picker'
+import { getCountries, getStates, getCountry } from 'country-state-picker'
 
 export interface Props {
     vals: TravelGroup['data']['destination'];
@@ -25,7 +25,7 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
 
     const [countryCode, setCountryCode] = useState('')
 
-    const states = useMemo(() => getStates(countryCode), [countryCode])
+    const states = useMemo(() => getStates(countryCode) || getStates(getCountry(vals.country)?.code || ''), [countryCode, vals])
 
     return (
         <Box>
@@ -53,7 +53,7 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
                         </Box>
                         {values.region !== 'Interregional' && <Box my={3}>
                             <FormGroup>
-                                <Autocomplete renderInput={(params) => (
+                                <Autocomplete value={values.country} renderInput={(params) => (
                                     <TextField {...params} label="Country" error={touched.country && Boolean(errors.country)}
                                     helperText={touched.country && errors.country ? errors.country : ''} />
                                 )} options={countries.map(country => country)} getOptionLabel={(option:any) => option.name || option} 

--- a/src/components/forms/travel-groups/create/Destination.tsx
+++ b/src/components/forms/travel-groups/create/Destination.tsx
@@ -25,7 +25,7 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
 
     const [countryCode, setCountryCode] = useState('')
 
-    const states = useMemo(() => getStates(countryCode) || getStates(getCountry(vals.country)?.code || ''), [countryCode, vals])
+    const states = useMemo(() => getStates(countryCode) || getStates(getCountry(vals.country)?.code || '') || [], [countryCode, vals])
 
     return (
         <Box>
@@ -56,14 +56,14 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
                                 <Autocomplete value={values.country} renderInput={(params) => (
                                     <TextField {...params} label="Country" error={touched.country && Boolean(errors.country)}
                                     helperText={touched.country && errors.country ? errors.country : ''} />
-                                )} options={countries.map(country => country)} getOptionLabel={(option:any) => option.name || option} 
+                                )} options={[...countries, ""]} getOptionLabel={(option:any) => option.name || option} 
                                 onChange={(e, value) => {
                                     setFieldValue('country', value?.name || '')
                                     setFieldValue('state', '')
                                     setFieldValue('city', '')
                                     setFieldValue('address', '')
                                     setCountryCode(value?.code || '')
-                                }} />
+                                }} isOptionEqualToValue={(option, value) => option?.name === value || option === value} />
                             </FormGroup>
                         </Box>}
                         {values.country && <Box my={3}>
@@ -71,7 +71,7 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
                                 <Autocomplete value={values.state} renderInput={(params) => (
                                     <TextField {...params} label="State/Province" error={touched.state && Boolean(errors.state)}
                                     helperText={touched.state && errors.state ? errors.state : ''} />
-                                )} options={states} onChange={(e, value) => setFieldValue('state', value || '')} />
+                                )} options={[...states, ""]} onChange={(e, value) => setFieldValue('state', value || '')} />
                             </FormGroup>
                        </Box>}
                         {values.state && <Box my={3}>

--- a/src/components/forms/travel-groups/create/Destination.tsx
+++ b/src/components/forms/travel-groups/create/Destination.tsx
@@ -15,7 +15,7 @@ export interface Props {
 }
 
 const possibleRegions = ['Interregional', 'U.S. & Canada', 'Central America', 'South America', 'Europe', 
-    'Asia', 'Africa', 'Oceania', 'Antarctica']
+    'Asia', 'Africa', 'Oceania', 'Antarctica'].sort()
 
 export default function Destination({vals, onSubmit, setFormContext}:Props) {
 
@@ -59,13 +59,16 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
                                 )} options={countries.map(country => country)} getOptionLabel={(option:any) => option.name || option} 
                                 onChange={(e, value) => {
                                     setFieldValue('country', value?.name || '')
+                                    setFieldValue('state', '')
+                                    setFieldValue('city', '')
+                                    setFieldValue('address', '')
                                     setCountryCode(value?.code || '')
                                 }} />
                             </FormGroup>
                         </Box>}
                         {values.country && <Box my={3}>
                             <FormGroup>
-                                <Autocomplete renderInput={(params) => (
+                                <Autocomplete value={values.state} renderInput={(params) => (
                                     <TextField {...params} label="State/Province" error={touched.state && Boolean(errors.state)}
                                     helperText={touched.state && errors.state ? errors.state : ''} />
                                 )} options={states} onChange={(e, value) => setFieldValue('state', value || '')} />
@@ -73,12 +76,12 @@ export default function Destination({vals, onSubmit, setFormContext}:Props) {
                        </Box>}
                         {values.state && <Box my={3}>
                             <FormGroup>
-                                <FormikTextField name="city" label="City" />
+                                <FormikTextField name="city" label="City" value={values.city} />
                             </FormGroup>
                         </Box>}
                         {values.city && <Box my={3}>
                             <FormGroup>
-                                <FormikTextField name="address" label="Address" />
+                                <FormikTextField name="address" label="Address" value={values.address} />
                             </FormGroup> 
                         </Box>}
                     </Form>

--- a/src/components/forms/travel-groups/create/Destination.tsx
+++ b/src/components/forms/travel-groups/create/Destination.tsx
@@ -1,0 +1,89 @@
+import React, { Dispatch, SetStateAction, useMemo, useState } from 'react'
+import {Box, FormGroup} from '@mui/material'
+import {Form, Formik, FormikHelpers} from 'formik'
+import {FormikSelectField, FormikTextField} from '../../FormikFields'
+import {object, string} from 'yup'
+import FormObserver from '../../FormObserver'
+import { TravelGroup } from '../../../../database/interfaces'
+import {MenuItem, Autocomplete, TextField} from '@mui/material'
+import { getCountries, getStates } from 'country-state-picker'
+
+export interface Props {
+    vals: TravelGroup['data']['destination'];
+    onSubmit: (vals:Props['vals'], actions:FormikHelpers<Props['vals']>) => void;
+    setFormContext?: Dispatch<SetStateAction<any>>;
+}
+
+const possibleRegions = ['Interregional', 'U.S. & Canada', 'Central America', 'South America', 'Europe', 
+    'Asia', 'Africa', 'Oceania', 'Antarctica']
+
+export default function Destination({vals, onSubmit, setFormContext}:Props) {
+
+    const initialVals = vals
+
+    const countries = useMemo(() => getCountries(), [])
+
+    const [countryCode, setCountryCode] = useState('')
+
+    const states = useMemo(() => getStates(countryCode), [countryCode])
+
+    return (
+        <Box>
+            <Formik validationSchema={object({
+                    region: string().oneOf(possibleRegions),
+                    country: string(),
+                    state: string().max(50),
+                    city: string().max(50),
+                    address: string().max(100)
+                })}
+                initialValues={initialVals} onSubmit={(values, actions) => onSubmit(values, actions)}>
+                {({values, errors, isSubmitting, isValidating, setFieldValue, touched}) => (
+                    <Form>
+                        {setFormContext && <FormObserver setFormContext={setFormContext} />}
+                        <Box my={3}>
+                            <FormGroup>
+                                <FormikSelectField name="region" label="Region" value={values.region}>
+                                    {possibleRegions.map(region => (
+                                        <MenuItem key={region} value={region}>
+                                            {region}
+                                        </MenuItem>
+                                    ))}
+                                </FormikSelectField>
+                            </FormGroup>
+                        </Box>
+                        {values.region !== 'Interregional' && <Box my={3}>
+                            <FormGroup>
+                                <Autocomplete renderInput={(params) => (
+                                    <TextField {...params} label="Country" error={touched.country && Boolean(errors.country)}
+                                    helperText={touched.country && errors.country ? errors.country : ''} />
+                                )} options={countries.map(country => country)} getOptionLabel={(option:any) => option.name || option} 
+                                onChange={(e, value) => {
+                                    setFieldValue('country', value?.name || '')
+                                    setCountryCode(value?.code || '')
+                                }} />
+                            </FormGroup>
+                        </Box>}
+                        {values.country && <Box my={3}>
+                            <FormGroup>
+                                <Autocomplete renderInput={(params) => (
+                                    <TextField {...params} label="State/Province" error={touched.state && Boolean(errors.state)}
+                                    helperText={touched.state && errors.state ? errors.state : ''} />
+                                )} options={states} onChange={(e, value) => setFieldValue('state', value || '')} />
+                            </FormGroup>
+                       </Box>}
+                        {values.state && <Box my={3}>
+                            <FormGroup>
+                                <FormikTextField name="city" label="City" />
+                            </FormGroup>
+                        </Box>}
+                        {values.city && <Box my={3}>
+                            <FormGroup>
+                                <FormikTextField name="address" label="Address" />
+                            </FormGroup> 
+                        </Box>}
+                    </Form>
+                )}
+            </Formik>
+        </Box>
+    )
+}

--- a/src/components/forms/travel-groups/create/General.tsx
+++ b/src/components/forms/travel-groups/create/General.tsx
@@ -1,0 +1,46 @@
+import React, { Dispatch, SetStateAction } from 'react'
+import {Box, FormGroup} from '@mui/material'
+import {Form, Formik, FormikHelpers} from 'formik'
+import {FormikTextField} from '../../FormikFields'
+import {object, string} from 'yup'
+import FormObserver from '../../FormObserver'
+
+export interface Props {
+    vals: {
+        name: string;
+        desc: string;
+    };
+    onSubmit: (vals:Props['vals'], actions:FormikHelpers<Props['vals']>) => void;
+    setFormContext?: Dispatch<SetStateAction<any>>;
+}
+
+export default function General({vals, onSubmit, setFormContext}:Props) {
+
+    const initialVals = vals
+
+    return (
+        <Box>
+            <Formik validationSchema={object({
+                    name: string().required('Please enter a name.').max(70),
+                    desc: string().max(600)
+                })}
+                initialValues={initialVals} onSubmit={(values, actions) => onSubmit(values, actions)}>
+                {({values, errors, isSubmitting, isValidating}) => (
+                    <Form>
+                        {setFormContext && <FormObserver setFormContext={setFormContext} />}
+                        <Box my={3}>
+                            <FormGroup>
+                                <FormikTextField name="name" label="Name" />
+                            </FormGroup>
+                        </Box>
+                        <Box my={3}>
+                            <FormGroup>
+                                <FormikTextField name="desc" label="Description" multiline rows={12} />
+                            </FormGroup>
+                        </Box>
+                    </Form>
+                )}
+            </Formik>
+        </Box>
+    )
+}

--- a/src/components/forms/travel-groups/create/Settings.tsx
+++ b/src/components/forms/travel-groups/create/Settings.tsx
@@ -50,7 +50,7 @@ export default function Settings({vals, onSubmit, setFormContext}:Props) {
                         <Box my={5}>
                             <FormGroup>
                                 <FormControl>
-                                    <Typography variant="body1" color="text.secondary">Invite Priveleges</Typography>
+                                    <Typography variant="body1" color="text.secondary">Invite Privileges</Typography>
                                     <RadioGroup value={values.invitePriveleges}
                                      onChange={(e) => setFieldValue('invitePriveleges', e.target.value)}>
                                          <Box my={1}>
@@ -68,7 +68,7 @@ export default function Settings({vals, onSubmit, setFormContext}:Props) {
                         <Box my={5}>
                             <FormGroup>
                                 <FormControl>
-                                    <Typography variant="body1" color="text.secondary">Join Request Priveleges</Typography>
+                                    <Typography variant="body1" color="text.secondary">Join Request Privileges</Typography>
                                     <RadioGroup value={values.joinRequestPriveleges}
                                     onChange={(e) => setFieldValue('joinRequestPriveleges', e.target.value)}>
                                         <Box my={1}>

--- a/src/components/forms/travel-groups/create/Settings.tsx
+++ b/src/components/forms/travel-groups/create/Settings.tsx
@@ -1,0 +1,91 @@
+import React, { Dispatch, SetStateAction } from 'react'
+import {Box, FormControl, FormGroup, FormLabel, RadioGroup, Grid, Radio, Typography} from '@mui/material'
+import {Form, Formik, FormikHelpers} from 'formik'
+import {FormikTextField, RadioWithDesc} from '../../FormikFields'
+import {object, string} from 'yup'
+import FormObserver from '../../FormObserver'
+
+export interface Props {
+    vals: {
+        mode: string;
+        invitePriveleges: string;
+        joinRequestPriveleges: string;
+    }
+    onSubmit: (vals:Props['vals'], actions:FormikHelpers<Props['vals']>) => void;
+    setFormContext?: Dispatch<SetStateAction<any>>;    
+}
+
+export default function Settings({vals, onSubmit, setFormContext}:Props) {
+
+    const initialVals = vals
+
+    return (
+        <Box>
+            <Formik validationSchema={object({
+                    mode: string().oneOf(["public", "private"]),
+                    invitePriveleges: string().oneOf(["ownerOnly", "allMembers"]),
+                    joinRequestPriveleges: string().oneOf(["ownerOnly", "allMembers"])
+                })}
+                initialValues={initialVals} onSubmit={(values, actions) => onSubmit(values, actions)}>
+                {({values, errors, isSubmitting, isValidating, setFieldValue}) => (
+                    <Form>
+                        {setFormContext && <FormObserver setFormContext={setFormContext} />}
+                        <Box my={3}>
+                            <FormGroup>
+                                <FormControl>
+                                    <Typography variant="body1" color="text.secondary">Privacy</Typography>
+                                    <RadioGroup value={values.mode} onChange={(e) => setFieldValue('mode', e.target.value)}>
+                                        <Box my={1}>
+                                            <RadioWithDesc value="public" selectedValue={values.mode} primaryText="Public"
+                                            secondaryText="Anyone can preview this group and request to join." />
+                                        </Box>
+                                        <Box>
+                                            <RadioWithDesc value="private" selectedValue={values.mode} primaryText="Private"
+                                            secondaryText="Only people invited can preview and join the group." />
+                                        </Box>
+                                    </RadioGroup>
+                                </FormControl>
+                            </FormGroup>
+                        </Box>
+                        <Box my={5}>
+                            <FormGroup>
+                                <FormControl>
+                                    <Typography variant="body1" color="text.secondary">Invite Priveleges</Typography>
+                                    <RadioGroup value={values.invitePriveleges}
+                                     onChange={(e) => setFieldValue('invitePriveleges', e.target.value)}>
+                                         <Box my={1}>
+                                             <RadioWithDesc value="ownerOnly" selectedValue={values.invitePriveleges} primaryText="Owner Only"
+                                             secondaryText="Only the owner can invite travelers." />
+                                         </Box>
+                                         <Box>
+                                             <RadioWithDesc value="allMembers" selectedValue={values.invitePriveleges} primaryText="Any Member"
+                                             secondaryText="Any member can invite travelers." />
+                                         </Box>
+                                     </RadioGroup>
+                                </FormControl>
+                            </FormGroup>
+                        </Box>
+                        <Box my={5}>
+                            <FormGroup>
+                                <FormControl>
+                                    <Typography variant="body1" color="text.secondary">Join Request Priveleges</Typography>
+                                    <RadioGroup value={values.joinRequestPriveleges}
+                                    onChange={(e) => setFieldValue('joinRequestPriveleges', e.target.value)}>
+                                        <Box my={1}>
+                                            <RadioWithDesc value="ownerOnly" selectedValue={values.joinRequestPriveleges}
+                                            primaryText="Owner Only" secondaryText="Only the owner can respond to join requests." />
+                                        </Box>
+                                        <Box>
+                                            <RadioWithDesc value="allMembers" selectedValue={values.joinRequestPriveleges}
+                                            primaryText="Any Member" secondaryText="Any member can respond to join requests." />
+                                        </Box>
+                                    </RadioGroup>
+                                </FormControl>
+                            </FormGroup>
+                        </Box>
+                    </Form>
+                )}
+            </Formik>
+        </Box>
+    )
+}

--- a/src/components/travel-groups/create/DateSelection.tsx
+++ b/src/components/travel-groups/create/DateSelection.tsx
@@ -1,6 +1,7 @@
 import { Box, RadioGroup, Radio, FormControl, FormControlLabel, Container, Grid, FormLabel, Typography, Collapse } from "@mui/material";
 import Calendar from "../../calendar/Calendar";
-import {ChangeEvent} from 'react'
+import {ChangeEvent, useMemo} from 'react'
+import dayjs, { Dayjs } from "dayjs";
 
 export interface Props {
     date: {
@@ -16,6 +17,14 @@ export default function DateSelection({date, setDate}:Props) {
 
     const handleCertaintyChange = (e:ChangeEvent<HTMLInputElement>) => {
         setDate({...date, unknown: e.target.value === 'unknown', roughly: e.target.value === 'roughly'})
+    }
+
+    const dateRange = useMemo<[Dayjs, Dayjs]>(() => {
+        return [date.start ? dayjs(date.start) : null, date.end ? dayjs(date.end) : null]
+    }, [date])
+
+    const onDateChange = ([start, end]:[Dayjs, Dayjs]) => {
+        setDate({...date, start: start.format('YYYY-MM-DD'), end: end.format('YYYY-MM-DD')})
     }
 
     return (
@@ -57,7 +66,7 @@ export default function DateSelection({date, setDate}:Props) {
                                                 </Box>
                                                 <Box>
                                                     <Typography color="rgba(0,0,0,0.7)" variant="subtitle1">
-                                                        e.g. Summer 2024
+                                                        e.g. Sometime in Summer 2024
                                                     </Typography>
                                                 </Box>
                                             </label>
@@ -91,10 +100,12 @@ export default function DateSelection({date, setDate}:Props) {
                 </Container>
             </Box>
             <Collapse in={date.roughly}>
-                
+                <Calendar dateRange={dateRange} onDateRangeChange={onDateChange} />
+                {/* earliest start and end */}
             </Collapse>
             <Collapse in={!date.unknown && !date.roughly}>
-                <Calendar />
+                <Calendar dateRange={dateRange} onDateRangeChange={onDateChange} />
+                {/* start and end  */}
             </Collapse>
         </Box>
     )

--- a/src/components/travel-groups/create/DateSelection.tsx
+++ b/src/components/travel-groups/create/DateSelection.tsx
@@ -1,0 +1,11 @@
+import { Box } from "@mui/material";
+import Calendar from "../../calendar/Calendar";
+
+export default function DateSelection() {
+
+    return (
+        <Box>
+            <Calendar />
+        </Box>
+    )
+}

--- a/src/components/travel-groups/create/DateSelection.tsx
+++ b/src/components/travel-groups/create/DateSelection.tsx
@@ -164,10 +164,13 @@ export default function DateSelection({date, setDate}:Props) {
                         </Typography>
                     </Box>
                 </Container>
-                <Calendar dateRange={dateRange} onDateRangeChange={onDateRangeChange} />
+                <Box sx={{display: {xs: 'none', sm: 'block'}}}>
+                    <Calendar dateRange={dateRange} onDateRangeChange={onDateRangeChange} />
+                </Box>
             </Collapse>
             {!date.unknown && <Box mt={3} mb={8}>
-                <Grid container spacing={3} alignItems="center" justifyContent="center">
+                <Grid container spacing={3} alignItems="center" justifyContent="center"
+                sx={{flexDirection: {xs: 'column', sm: 'row'}}} wrap="nowrap">
                     {date.roughly && <Grid item>
                         <Typography variant="body1">
                             Between

--- a/src/components/travel-groups/create/DateSelection.tsx
+++ b/src/components/travel-groups/create/DateSelection.tsx
@@ -1,11 +1,101 @@
-import { Box } from "@mui/material";
+import { Box, RadioGroup, Radio, FormControl, FormControlLabel, Container, Grid, FormLabel, Typography, Collapse } from "@mui/material";
 import Calendar from "../../calendar/Calendar";
+import {ChangeEvent} from 'react'
 
-export default function DateSelection() {
+export interface Props {
+    date: {
+        unknown: boolean;
+        roughly: boolean;
+        start: string;
+        end: string;
+    };
+    setDate: (date:Props['date']) => void;
+}
+
+export default function DateSelection({date, setDate}:Props) {
+
+    const handleCertaintyChange = (e:ChangeEvent<HTMLInputElement>) => {
+        setDate({...date, unknown: e.target.value === 'unknown', roughly: e.target.value === 'roughly'})
+    }
 
     return (
         <Box>
-            <Calendar />
+            <Box>
+                <Container maxWidth="sm">
+                    <Box>
+                        <FormControl>
+                            <RadioGroup name="date-certainty" 
+                            value={date.unknown ? 'unknown' : date.roughly ? 'roughly' : 'certain'}
+                            onChange={(e) => handleCertaintyChange(e)} >
+                                <Box mb={2}>
+                                    <Grid container spacing={3} wrap="nowrap" alignItems="center">
+                                        <Grid item>
+                                            <Radio id="date-certainty-unknown" value="unknown" />
+                                        </Grid>
+                                        <Grid item>
+                                            <label htmlFor="date-certainty-unknown">
+                                                <Box>
+                                                    <Typography variant="h6">
+                                                        I don't know when we'll travel.
+                                                    </Typography>
+                                                </Box>
+                                            </label>
+                                        </Grid>
+                                    </Grid>
+                                </Box>
+                                <Box mb={2}>
+                                    <Grid container spacing={3} wrap="nowrap" alignItems="center">
+                                        <Grid item>
+                                            <Radio id="date-certainty-roughly" value="roughly" />
+                                        </Grid>
+                                        <Grid item>
+                                            <label htmlFor="date-certainty-roughly">
+                                                <Box>
+                                                    <Typography variant="h6">
+                                                        I know roughly when we'll travel.
+                                                    </Typography>
+                                                </Box>
+                                                <Box>
+                                                    <Typography color="rgba(0,0,0,0.7)" variant="subtitle1">
+                                                        e.g. Summer 2024
+                                                    </Typography>
+                                                </Box>
+                                            </label>
+                                        </Grid>
+                                    </Grid>
+                                </Box>
+                                <Box>
+                                    <Grid container spacing={3} wrap="nowrap" alignItems="center">
+                                        <Grid item>
+                                            <Radio id="date-certainty-certain" value="certain" />
+                                        </Grid>
+                                        <Grid item>
+                                            <label htmlFor="date-certainty-certain">
+                                                <Box>
+                                                    <Typography variant="h6">
+                                                        I know when we'll travel.
+                                                    </Typography>
+                                                </Box>
+                                                <Box>
+                                                    <Typography variant="subtitle1" color="rgba(0,0,0,0.7)">
+                                                        e.g. March 20 to March 25
+                                                    </Typography>
+                                                </Box>
+                                            </label>
+                                        </Grid>
+                                    </Grid>
+                                </Box>
+                            </RadioGroup>
+                        </FormControl>
+                    </Box>
+                </Container>
+            </Box>
+            <Collapse in={date.roughly}>
+                
+            </Collapse>
+            <Collapse in={!date.unknown && !date.roughly}>
+                <Calendar />
+            </Collapse>
         </Box>
     )
 }

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -1,0 +1,16 @@
+import { Box } from "@mui/material";
+import { ClientUser } from "../../../database/interfaces";
+
+interface Props {
+    user: ClientUser;
+    travelDates: {start:{'@ts':string};end:{'@ts':string}}[];
+}
+
+export default function Main({user, travelDates}:Props) {
+
+    return (
+        <Box>
+            main section
+        </Box>
+    )
+}

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -6,7 +6,7 @@ import { OrangePrimaryButton, OrangeSecondaryButton } from "../../mui-customizat
 import GeneralForm from '../../forms/travel-groups/create/General'
 import DestinationForm from '../../forms/travel-groups/create/Destination'
 import CloseIcon from '@mui/icons-material/Close'
-import DateSelection from "./DateSelection";
+import DateSelection, {Props as DateProps} from "./DateSelection";
 
 interface Props {
     user: ClientUser;
@@ -33,6 +33,8 @@ export default function Main({user}:Props) {
             country: '', state: '', city: '', address: ''
         },
         date: {
+            unknown: true,
+            roughly: false,
             start: '',
             end: ''
         },
@@ -78,6 +80,10 @@ export default function Main({user}:Props) {
         setStep(step - 1)
     }
 
+    const setDate = (date:DateProps['date']) => {
+        setTotalInfo({...totalInfo, date})
+    }
+
     return (
         <Box mt={3}>
             <Container maxWidth="md">
@@ -113,7 +119,7 @@ export default function Main({user}:Props) {
                                     step === 1 ? <DestinationForm vals={totalInfo.destination as any} 
                                     onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : ''}
                                 </Container>
-                                {step === 2 && <DateSelection />}
+                                {step === 2 && <DateSelection date={totalInfo.date} setDate={setDate} />}
                             </Box>
                             <Box mt={2}>
                                 <Grid container spacing={3} justifyContent="center">

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -48,7 +48,10 @@ export default function Main({user}:Props) {
 
     const updateTotalInfo = (values) => {
         if (step === 1) {
-            setTotalInfo({...totalInfo, destination: values})
+            setTotalInfo({...totalInfo, destination: {
+                ...values,
+                combo: [values.region, values.country, values.state, values.city, values.address].join('$$')
+            }})
         } else {
             setTotalInfo({...totalInfo, ...values})
         }

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -10,10 +10,9 @@ import DateSelection from "./DateSelection";
 
 interface Props {
     user: ClientUser;
-    travelDates: {start:{'@ts':string};end:{'@ts':string}}[];
 }
 
-export default function Main({user, travelDates}:Props) {
+export default function Main({user}:Props) {
 
     const displayLabels = useMediaQuery('(min-width:450px)')
 

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -1,5 +1,10 @@
-import { Box } from "@mui/material";
+import { Box, Container, Paper, Step, StepLabel, Stepper, useMediaQuery, Grid } from "@mui/material";
+import { useMemo, useState } from "react";
 import { ClientUser } from "../../../database/interfaces";
+import {FormikContextType, FormikHelpers} from 'formik'
+import { OrangePrimaryButton, OrangeSecondaryButton } from "../../mui-customizations/buttons";
+import GeneralForm from '../../forms/travel-groups/create/General'
+import DestinationForm from '../../forms/travel-groups/create/Destination'
 
 interface Props {
     user: ClientUser;
@@ -8,9 +13,111 @@ interface Props {
 
 export default function Main({user, travelDates}:Props) {
 
+    const displayLabels = useMediaQuery('(min-width:450px)')
+
+    const [step, setStep] = useState(0)
+    const [formContexts, setFormContexts] = useState<FormikContextType<any>[]>(Array(4).fill(null))
+
+    const labels = useMemo(() => ['General', 'Destination', 'Date', 'Settings'] ,[])
+
+    const [totalInfo, setTotalInfo] = useState({
+        owner: user.ref['@ref'].id,
+        members: [user.ref['@ref'].id],
+        name: '',
+        desc: '',
+        destination: {
+            combo: '',
+            region: 'Interregional',
+            country: '', state: '', city: '', address: ''
+        },
+        date: {
+            start: '',
+            end: ''
+        },
+        settings: {
+            mode: 'public',
+            invitePriveleges: 'ownerOnly',
+            joinRequestPriveleges: 'ownerOnly'
+        }
+    })
+
+    const updateTotalInfo = (values) => {
+        if (step === 1) {
+            setTotalInfo({...totalInfo, destination: values})
+        } else {
+            setTotalInfo({...totalInfo, ...values})
+        }
+    }
+
+    const onSectionSubmit = (values, actions:FormikHelpers<any>) => {
+        updateTotalInfo(values)
+        if (step < 3) {
+            setStep(step + 1)
+        }
+    }
+
+    const updateFormContext = (formContext:FormikContextType<any>) => {
+        const contextCopy = [...formContexts]
+        contextCopy[step] = formContext
+        setFormContexts(contextCopy) 
+    }
+
+    const next = async () => {
+        formContexts[step].setSubmitting(true)
+        await formContexts[step].submitForm()
+    }
+
+    const back = () => {
+        updateTotalInfo(formContexts[step].values)
+        setStep(step - 1)
+    }
+
     return (
-        <Box>
-            main section
+        <Box mt={3}>
+            <Container maxWidth="md">
+                <Paper elevation={5}>
+                    <Box py={3} mx={3}>
+                        <Box mb={5}>
+                            <Stepper alternativeLabel activeStep={step}>
+                                {labels.map((label, i) => (
+                                    <Step key={label} completed={i < step}>
+                                        <StepLabel>
+                                            {displayLabels && label}
+                                        </StepLabel>
+                                    </Step>
+                                ))}
+                            </Stepper>
+                        </Box>
+                        <Box minHeight="70vh" display="flex" flexDirection="column" justifyContent="space-between">
+                            <Box>
+                                <Container maxWidth="sm">
+                                    {step === 0 ? <GeneralForm vals={{name: totalInfo.name, desc: totalInfo.desc}}
+                                    onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : 
+                                    step === 1 ? <DestinationForm vals={totalInfo.destination as any} 
+                                    onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : ''}
+                                </Container>
+                            </Box>
+                            <Box mt={2}>
+                                <Grid container spacing={3} justifyContent="center">
+                                    {step !== 0 && <Grid item>
+                                        <OrangeSecondaryButton onClick={() => back()} sx={{minWidth: 150}}>
+                                            Back     
+                                        </OrangeSecondaryButton> 
+                                    </Grid>}
+                                    <Grid item>
+                                        {step < 3 ? <OrangePrimaryButton onClick={() => next()}
+                                        disabled={formContexts[step]?.isSubmitting} sx={{minWidth: 150}}>
+                                            Next
+                                        </OrangePrimaryButton> : <OrangePrimaryButton sx={{minWidth: 150}}>
+                                            Finish     
+                                        </OrangePrimaryButton>}
+                                    </Grid>
+                                </Grid>
+                            </Box>
+                        </Box>
+                    </Box>
+                </Paper>
+            </Container>
         </Box>
     )
 }

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -36,7 +36,8 @@ export default function Main({user}:Props) {
             unknown: true,
             roughly: false,
             start: '',
-            end: ''
+            end: '',
+            estLength: [7, 'days'] as [number, string]
         },
         settings: {
             mode: 'public',

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -6,6 +6,7 @@ import { OrangePrimaryButton, OrangeSecondaryButton } from "../../mui-customizat
 import GeneralForm from '../../forms/travel-groups/create/General'
 import DestinationForm from '../../forms/travel-groups/create/Destination'
 import CloseIcon from '@mui/icons-material/Close'
+import DateSelection from "./DateSelection";
 
 interface Props {
     user: ClientUser;
@@ -109,6 +110,7 @@ export default function Main({user, travelDates}:Props) {
                                     step === 1 ? <DestinationForm vals={totalInfo.destination as any} 
                                     onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : ''}
                                 </Container>
+                                {step === 2 && <DateSelection />}
                             </Box>
                             <Box mt={2}>
                                 <Grid container spacing={3} justifyContent="center">

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -1,10 +1,11 @@
-import { Box, Container, Paper, Step, StepLabel, Stepper, useMediaQuery, Grid } from "@mui/material";
+import { Box, Container, Paper, Step, StepLabel, Stepper, useMediaQuery, Grid, Alert, AlertTitle, Collapse, IconButton } from "@mui/material";
 import { useMemo, useState } from "react";
 import { ClientUser } from "../../../database/interfaces";
 import {FormikContextType, FormikHelpers} from 'formik'
 import { OrangePrimaryButton, OrangeSecondaryButton } from "../../mui-customizations/buttons";
 import GeneralForm from '../../forms/travel-groups/create/General'
 import DestinationForm from '../../forms/travel-groups/create/Destination'
+import CloseIcon from '@mui/icons-material/Close'
 
 interface Props {
     user: ClientUser;
@@ -17,6 +18,7 @@ export default function Main({user, travelDates}:Props) {
 
     const [step, setStep] = useState(0)
     const [formContexts, setFormContexts] = useState<FormikContextType<any>[]>(Array(4).fill(null))
+    const [destAlert, setDestAlert] = useState(true)
 
     const labels = useMemo(() => ['General', 'Destination', 'Date', 'Settings'] ,[])
 
@@ -91,6 +93,17 @@ export default function Main({user, travelDates}:Props) {
                         <Box minHeight="70vh" display="flex" flexDirection="column" justifyContent="space-between">
                             <Box>
                                 <Container maxWidth="sm">
+                                    {step === 1 && destAlert && <Box>
+                                        <Collapse in={destAlert}>
+                                            <Alert severity="info" action={<IconButton onClick={() => setDestAlert(false)}>
+                                                <CloseIcon /> 
+                                            </IconButton>}>
+                                                <AlertTitle>
+                                                    Provide as detailed information about the destination as possible.     
+                                                </AlertTitle> 
+                                            </Alert>
+                                        </Collapse>
+                                   </Box>}
                                     {step === 0 ? <GeneralForm vals={{name: totalInfo.name, desc: totalInfo.desc}}
                                     onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : 
                                     step === 1 ? <DestinationForm vals={totalInfo.destination as any} 

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -53,7 +53,9 @@ export default function Main({user, travelDates}:Props) {
     }
 
     const onSectionSubmit = (values, actions:FormikHelpers<any>) => {
-        updateTotalInfo(values)
+        if (step !== 3) {
+            updateTotalInfo(values)
+        }
         if (step < 3) {
             setStep(step + 1)
         }
@@ -71,7 +73,9 @@ export default function Main({user, travelDates}:Props) {
     }
 
     const back = () => {
-        updateTotalInfo(formContexts[step].values)
+        if (step !== 2) {
+            updateTotalInfo(formContexts[step].values)
+        }
         setStep(step - 1)
     }
 

--- a/src/components/travel-groups/create/Main.tsx
+++ b/src/components/travel-groups/create/Main.tsx
@@ -5,6 +5,7 @@ import {FormikContextType, FormikHelpers} from 'formik'
 import { OrangePrimaryButton, OrangeSecondaryButton } from "../../mui-customizations/buttons";
 import GeneralForm from '../../forms/travel-groups/create/General'
 import DestinationForm from '../../forms/travel-groups/create/Destination'
+import SettingsForm from '../../forms/travel-groups/create/Settings'
 import CloseIcon from '@mui/icons-material/Close'
 import DateSelection, {Props as DateProps} from "./DateSelection";
 
@@ -19,6 +20,7 @@ export default function Main({user}:Props) {
     const [step, setStep] = useState(0)
     const [formContexts, setFormContexts] = useState<FormikContextType<any>[]>(Array(4).fill(null))
     const [destAlert, setDestAlert] = useState(true)
+    const [creatingGroup, setCreatingGroup] = useState(false)
 
     const labels = useMemo(() => ['General', 'Destination', 'Date', 'Settings'] ,[])
 
@@ -58,11 +60,9 @@ export default function Main({user}:Props) {
     }
 
     const onSectionSubmit = (values, actions:FormikHelpers<any>) => {
-        if (step !== 3) {
-            updateTotalInfo(values)
-        }
+        updateTotalInfo(values)
         if (step < 3) {
-            setStep(step + 1)
+            return setStep(step + 1)
         }
     }
 
@@ -73,6 +73,9 @@ export default function Main({user}:Props) {
     }
 
     const next = async () => {
+        if (step === 2) {
+            return setStep(step + 1)
+        }
         formContexts[step].setSubmitting(true)
         await formContexts[step].submitForm()
     }
@@ -86,6 +89,17 @@ export default function Main({user}:Props) {
 
     const setDate = (date:DateProps['date']) => {
         setTotalInfo({...totalInfo, date})
+    }
+
+    const createGroup = async () => {
+        await next()
+        setCreatingGroup(true)
+
+        try {
+            
+        } catch (e) {
+            setCreatingGroup(false)
+        }
     }
 
     return (
@@ -121,7 +135,9 @@ export default function Main({user}:Props) {
                                     {step === 0 ? <GeneralForm vals={{name: totalInfo.name, desc: totalInfo.desc}}
                                     onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : 
                                     step === 1 ? <DestinationForm vals={totalInfo.destination as any} 
-                                    onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : ''}
+                                    onSubmit={onSectionSubmit} setFormContext={updateFormContext} /> : 
+                                    step === 3 ? <SettingsForm vals={totalInfo.settings} onSubmit={onSectionSubmit}
+                                    setFormContext={updateFormContext} /> : ''}
                                 </Container>
                                 {step === 2 && <DateSelection date={totalInfo.date} setDate={setDate} />}
                             </Box>
@@ -136,7 +152,8 @@ export default function Main({user}:Props) {
                                         {step < 3 ? <OrangePrimaryButton onClick={() => next()}
                                         disabled={formContexts[step]?.isSubmitting} sx={{minWidth: 150}}>
                                             Next
-                                        </OrangePrimaryButton> : <OrangePrimaryButton sx={{minWidth: 150}}>
+                                        </OrangePrimaryButton> : <OrangePrimaryButton onClick={() => createGroup()}
+                                        disabled={formContexts[step]?.isSubmitting} sx={{minWidth: 150}}>
                                             Finish     
                                         </OrangePrimaryButton>}
                                     </Grid>

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -129,8 +129,10 @@ export interface TravelGroup {
             address?: string;
         };
         date: {
-            start: Date;
-            end: Date;
+            unknown: boolean;
+            roughly: boolean;
+            start: Expr; // Time
+            end: Expr; // Time
         };
         settings: {
             mode: 'public' | 'private';

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -17,7 +17,6 @@ interface UserData {
         publicId?: string;
     };
     friends?: string[];
-    status?: string; // id of a Status
     oAuthIdentifier?: {
         google?: string;
     }
@@ -42,12 +41,14 @@ export interface ClientFilteredUser extends Omit<ClientUser, 'data'> {
 
 interface YearStatus {
     unavailable: number[];
-    traveling: string[]; // Travel Groups
 }
 
 export interface Status {
     ref: Ref;
-    data: Map<string, YearStatus>;
+    data: {
+        dates: Map<string, YearStatus>;
+        userId: string;
+    };
 }
 
 export interface FriendRequest {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -132,6 +132,7 @@ export interface TravelGroup {
         date: {
             unknown: boolean;
             roughly: boolean;
+            estLength: [number, string];
             start: Expr; // Time
             end: Expr; // Time
         };

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -114,32 +114,44 @@ export interface PasswordResetToken {
     }
 }
 
+export interface TravelGroupData {
+    owner: string;
+    members: string[];
+    name: string;
+    desc: string;
+    destination: {
+        combo: string;
+        region: 'Interregional' | 'U.S. & Canada' | 'Central America' | 'South America' | 'Europe' | 'Asia' | 'Africa' | 'Oceania' | 'Antarctica',
+        country?: string;
+        state?: string;
+        city?: string;
+        address?: string;
+    };
+    date: {
+        unknown: boolean;
+        roughly: boolean;
+        estLength: [number, string];
+        start: Expr; // Time
+        end: Expr; // Time
+    };
+    settings: {
+        mode: 'public' | 'private';
+        invitePriveleges: 'ownerOnly' | 'anyMember';
+        joinRequestPriveleges: 'ownerOnly' | 'anyMember';
+    }
+}
+
+export interface ClientTravelGroupData extends Omit<TravelGroupData, 'date'> {
+    date: {
+        unknown: boolean;
+        roughly: boolean;
+        estLength: [number, string];
+        start: string;
+        end: string;
+    }
+}
+
 export interface TravelGroup {
     ref: Ref;
-    data: {
-        owner: string;
-        members: string[];
-        name: string;
-        desc: string;
-        destination: {
-            combo: string;
-            region: 'Interregional' | 'U.S. & Canada' | 'Central America' | 'South America' | 'Europe' | 'Asia' | 'Africa' | 'Oceania' | 'Antarctica',
-            country?: string;
-            state?: string;
-            city?: string;
-            address?: string;
-        };
-        date: {
-            unknown: boolean;
-            roughly: boolean;
-            estLength: [number, string];
-            start: Expr; // Time
-            end: Expr; // Time
-        };
-        settings: {
-            mode: 'public' | 'private';
-            invitePriveleges: 'ownerOnly' | 'anyMember';
-            joinRequestPriveleges: 'ownerOnly' | 'anyMember';
-        }
-    }
+    data: TravelGroupData;
 }

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -102,3 +102,30 @@ export interface PasswordResetToken {
         userId: string;
     }
 }
+
+export interface TravelGroup {
+    ref: Ref;
+    data: {
+        owner: string;
+        members: string[];
+        name: string;
+        desc: string;
+        destination: {
+            combo: string;
+            region: 'Interregional' | 'U.S. & Canada' | 'Central America' | 'South America' | 'Europe' | 'Asia' | 'Africa' | 'Oceania' | 'Antarctica',
+            country?: string;
+            state?: string;
+            city?: string;
+            address?: string;
+        };
+        date: {
+            start: Date;
+            end: Date;
+        };
+        settings: {
+            mode: 'public' | 'private';
+            invitePriveleges: 'ownerOnly' | 'anyMember';
+            joinRequestPriveleges: 'ownerOnly' | 'anyMember';
+        }
+    }
+}

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -41,6 +41,7 @@ export interface ClientFilteredUser extends Omit<ClientUser, 'data'> {
 
 interface YearStatus {
     unavailable: number[];
+    available: number[];
 }
 
 export interface Status {

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -17,7 +17,7 @@ interface UserData {
         publicId?: string;
     };
     friends?: string[];
-    status?: any[]; // update later
+    status?: string; // id of a Status
     oAuthIdentifier?: {
         google?: string;
     }
@@ -38,6 +38,16 @@ interface FilteredUserData extends Omit<UserData, 'password'> {
 
 export interface ClientFilteredUser extends Omit<ClientUser, 'data'> {
     data: FilteredUserData;
+}
+
+interface YearStatus {
+    unavailable: number[];
+    traveling: string[]; // Travel Groups
+}
+
+export interface Status {
+    ref: Ref;
+    data: Map<string, YearStatus>;
 }
 
 export interface FriendRequest {

--- a/src/database/utils/travelGroups.ts
+++ b/src/database/utils/travelGroups.ts
@@ -11,8 +11,6 @@ export async function getUserTravelGroupDates(userId:string):Promise<{data: [str
 
 export async function createTravelGroup(data:ClientTravelGroupData):Promise<TravelGroup> {
 
-    console.log('data', data)
-
     const dbData = {...data, date: {
         ...data.date,
         start: q.Date(data.date.start),

--- a/src/database/utils/travelGroups.ts
+++ b/src/database/utils/travelGroups.ts
@@ -1,9 +1,25 @@
 import {query as q} from 'faunadb'
 import client from '../fauna'
+import { ClientTravelGroupData, TravelGroup } from '../interfaces'
 
 export async function getUserTravelGroupDates(userId:string):Promise<{data: [string, string][]}> {
 
     return await client.query(
         q.Paginate(q.Match(q.Index('travelGroups_by_members_w_date'), userId))
+    )
+}
+
+export async function createTravelGroup(data:ClientTravelGroupData):Promise<TravelGroup> {
+
+    console.log('data', data)
+
+    const dbData = {...data, date: {
+        ...data.date,
+        start: q.Date(data.date.start),
+        end: q.Date(data.date.end)
+    }}
+
+    return await client.query(
+        q.Create(q.Collection('travelGroups'), {data: dbData})
     )
 }

--- a/src/database/utils/travelGroups.ts
+++ b/src/database/utils/travelGroups.ts
@@ -1,0 +1,9 @@
+import {query as q} from 'faunadb'
+import client from '../fauna'
+
+export async function getUserTravelGroupDates(userId:string):Promise<{data: [string, string][]}> {
+
+    return await client.query(
+        q.Paginate(q.Match(q.Index('travelGroups_by_members_w_date'), userId))
+    )
+}

--- a/src/pages/api/travel-groups/create.ts
+++ b/src/pages/api/travel-groups/create.ts
@@ -1,0 +1,95 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { verifyUser } from "../../../utils/auth";
+import {createTravelGroup as dbCreateTravelGroup} from '../../../database/utils/travelGroups'
+import dayjs from "dayjs";
+
+const acceptedProperties = [{name: 'owner', type: 'string'}, {name: 'members', type: 'object'},
+ {name: 'name', type: 'string'}, {name: 'desc', type: 'string'}, {name: 'destination', type: 'object'},
+ {name: 'date', type: 'object'}, {name: 'settings', type: 'object'}]
+const destinationProperties = ['combo', 'region', 'country', 'state', 'city', 'address']
+const dateProperties = [{name: 'unknown', type: 'boolean'}, {name: 'roughly', type: 'boolean'}, 
+{name: 'start', type: 'string'}, {name: 'end', type: 'string'}, {name: 'estLength', type: 'object'}]
+const settingsProperties = ['mode', 'invitePriveleges', 'joinRequestPriveleges']
+
+function checkProperties(properties:Object) {
+    
+    if (!properties) throw 'No properties'
+
+    let foundProperties = 0
+
+    for (const [key, value] of Object.entries(properties)) {
+        foundProperties++
+        if (!acceptedProperties.find(prop => prop.name === key && prop.type === typeof value)) {
+            throw 'This is not an accepted property'
+        }
+        if (key === 'members' && !Array.isArray(value)) {
+            throw 'This is not an accepted property'
+        }
+        if (key === 'destination') {
+            const found = []
+            console.log(value)
+            for (const [destKey, destValue] of Object.entries(value)) {
+                found.push(destKey)
+                console.log(destKey)
+                if (!destinationProperties.find(prop => prop === destKey && (typeof destValue === 'string'))) {
+                    throw 'This is not an accepted property'
+                }
+            }
+            if (!found.includes('combo') || !found.includes('region')) {
+                throw 'Did not include all necessary properties'
+            }
+        }
+        if (key === 'date') {
+            let count = 0
+            for (const [dateKey, dateValue] of Object.entries(value)) {
+                count++
+                if (!dateProperties.find(prop => prop.name === dateKey && prop.type === typeof dateValue)) {
+                    throw 'This is not an accepted property'
+                }
+            }
+            if (count !== dateProperties.length) {
+                throw 'Did not include all necessary properties'
+            }
+        }
+        if (key === 'settings') {
+            let count = 0
+            for (const [settingsKey, settingsValue] of Object.entries(value)) {
+                count++
+                if (!settingsProperties.find(prop => prop === settingsKey && (typeof settingsValue === 'string'))) {
+                    throw 'This is not an accepted property'
+                }
+            }
+            if (count !== settingsProperties.length) {
+                throw 'Did not include all necessary properties'
+            }
+        }
+    }
+
+    if (foundProperties !== acceptedProperties.length) {
+        throw 'Did not include all necessary properties'
+    }
+}
+
+export default verifyUser(async function createTravelGroup(req:NextApiRequest, res:NextApiResponse) {
+
+    if (req.method !== 'POST') {
+        return res.status(400).json({msg: 'Ok...'})
+    }
+
+    try {
+
+        checkProperties(req.body.data)
+
+        if (!req.body.data.date.start) {
+            req.body.data.date.start = dayjs().add(1, 'week').format('YYYY-MM-DD')
+            req.body.data.date.end = dayjs().add(1, 'week').format('YYYY-MM-DD')
+        }
+
+        const group = await dbCreateTravelGroup(req.body.data)
+
+        return res.status(200).json({id: group.ref.id})
+    } catch (e) {
+        console.log(e)
+        return res.status(500).json({msg: 'Internal Server Error'})
+    }
+})

--- a/src/pages/travel-groups/create.tsx
+++ b/src/pages/travel-groups/create.tsx
@@ -1,0 +1,49 @@
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import { ClientUser } from "../../database/interfaces";
+import { getAuthUser } from "../../utils/auth";
+import Head from 'next/head'
+import styles from '../../styles/pages/HeaderFooter.module.css'
+import MainHeader from "../../components/nav/MainHeader";
+import { getUserTravelGroupDates } from "../../database/utils/travelGroups";
+import Main from '../../components/travel-groups/create/Main'
+
+interface Props {
+    user: ClientUser;
+    travelDates: {start:{'@ts':string};end:{'@ts':string}}[];
+}
+
+export default function CreateTravelGroup({user, travelDates}:Props) {
+
+    return (
+        <>
+            <Head>
+                <title>Create Travel Group | Travel Simply</title>     
+            </Head> 
+            <div className={styles.root}>
+                <MainHeader user={user} />
+                <div>
+                    <Main user={user} travelDates={travelDates} />
+                </div>
+                <div>
+                    footer
+                </div>
+            </div>
+        </>
+    )
+}
+
+export const getServerSideProps:GetServerSideProps = async (ctx:GetServerSidePropsContext) => {
+
+    const {user, redirect} = await getAuthUser(ctx)
+
+    if (redirect) {
+        return redirect
+    }
+
+    const travelDates = (await getUserTravelGroupDates(user.ref.id)).data.map(date => ({start: date[0], end: date[1]}))
+
+    return {props: {
+        user: JSON.parse(JSON.stringify(user)),
+        travelDates: JSON.parse(JSON.stringify(travelDates))
+    }}
+}

--- a/src/pages/travel-groups/create.tsx
+++ b/src/pages/travel-groups/create.tsx
@@ -9,10 +9,9 @@ import Main from '../../components/travel-groups/create/Main'
 
 interface Props {
     user: ClientUser;
-    travelDates: {start:{'@ts':string};end:{'@ts':string}}[];
 }
 
-export default function CreateTravelGroup({user, travelDates}:Props) {
+export default function CreateTravelGroup({user}:Props) {
 
     return (
         <>
@@ -22,7 +21,7 @@ export default function CreateTravelGroup({user, travelDates}:Props) {
             <div className={styles.root}>
                 <MainHeader user={user} />
                 <div>
-                    <Main user={user} travelDates={travelDates} />
+                    <Main user={user} />
                 </div>
                 <div>
                     footer
@@ -40,10 +39,7 @@ export const getServerSideProps:GetServerSideProps = async (ctx:GetServerSidePro
         return redirect
     }
 
-    const travelDates = (await getUserTravelGroupDates(user.ref.id)).data.map(date => ({start: date[0], end: date[1]}))
-
     return {props: {
         user: JSON.parse(JSON.stringify(user)),
-        travelDates: JSON.parse(JSON.stringify(travelDates))
     }}
 }

--- a/src/styles/Calendar.module.css
+++ b/src/styles/Calendar.module.css
@@ -57,10 +57,22 @@
     background: #fff;
     transition: 0.25s ease-out;
     padding-top: 1rem;
+    user-select: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
 }
 
 .calendar .body .cell:hover {
     background: hsl(30, 96%, 62.4%);
+}
+
+.calendar .body .cell.inRange {
+    background: hsl(30, 96%, 62.4%);
+}
+
+.calendar .body .cell.inPrevSelectedRange {
+    background: hsl(30, 96%, 45%);
 }
 
 .calendar .body .row {

--- a/src/styles/Calendar.module.css
+++ b/src/styles/Calendar.module.css
@@ -1,0 +1,94 @@
+.row {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 100%;
+}
+
+.rowMiddle {
+    align-items: center;
+}
+
+.column {
+    flex-grow: 1;
+    flex-basis: 0;
+    max-width: 100%;
+}
+
+.colCenter {
+    display: grid;
+    place-items: center;
+}
+
+.colStart {
+    text-align: start;
+}
+
+.colEnd {
+    text-align: end;
+}
+
+.calendar {
+    display: block;
+    position: relative;
+    height: auto;
+    margin:0 auto;
+}
+
+.calendar .header {
+    padding: 1.5em 0;
+    border-bottom: 1px solid lightgray;
+}
+
+.calendar .days {
+    color: rgba(0, 0, 0, .7);
+    padding: .75em 0;
+    border-bottom: 1px solid rgba(0, 0, 0, .2);
+}
+
+.calendar .body .cell {
+    position: relative;
+    height: 6em;
+    border-right: 1px solid rgba(0, 0, 0, .2);
+    overflow: hidden;
+    cursor: pointer;
+    background: #fff;
+    transition: 0.25s ease-out;
+    padding-top: 1rem;
+}
+
+.calendar .body .cell:hover {
+    background: hsl(30, 96%, 62.4%);
+}
+
+.calendar .body .row {
+    border-bottom: 1px solid lightgray;
+}
+
+.calendar .body .row:last-child {
+    border-bottom: none;
+}
+
+.calendar .body .cell:last-child {
+    border-right: none;
+}
+
+.calendar .body .cell .number {
+    position: absolute;
+    font-size: 82.5%;
+    line-height: 1;
+    top: .75em;
+    right: .75em;
+}
+
+.calendar .body .disabled {
+    pointer-events: none;
+}
+
+.calendar .body .column {
+    flex-grow: 0;
+    flex-basis: calc(100%/7);
+    width: calc(100%/7);
+}

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -20,6 +20,7 @@ export default createTheme({
     palette: {
         mode: 'light',
         primary: {
+            light: 'hsl(30, 96%, 62.4%)',
             main: 'hsl(30, 96%, 53%)', // orange,
             dark: 'hsl(30, 96%, 45%)'
         },

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -38,7 +38,8 @@ export default createTheme({
             light: 'hsl(30, 98%, 95%)'
         },
         text: {
-            primary: '#000'
+            primary: '#000',
+            secondary: 'rgba(0,0,0,0.7)'
         },
         error: {
             main: 'hsl(5, 95%, 50%)'


### PR DESCRIPTION
Added ability for users to create travel groups in four steps. 1) Entering a name and description. 2) Selecting a destination. 3) Selecting a date, estimated date, or unknown date. 4) Modifying settings. When users are able to modify their statuses, we will need to update the date selection calendar to indicate what days they are available, unavailable, unknown, or traveling. 